### PR TITLE
Multiple Relation Field lookups

### DIFF
--- a/armstrong/core/arm_sections/managers.py
+++ b/armstrong/core/arm_sections/managers.py
@@ -1,15 +1,10 @@
 from django.db import models
-from django.db.models import Q
 
 
 class SectionSlugManager(models.Manager):
-    def __init__(self,
-                 primary_section_field="primary_section",
-                 section_field="sections",
-                 slug_field="slug",
-                 *args, **kwargs):
+    def __init__(self, section_field="primary_section", slug_field="slug",
+            *args, **kwargs):
         super(SectionSlugManager, self).__init__(*args, **kwargs)
-        self.primary_section_field = primary_section_field
         self.section_field = section_field
         self.slug_field = slug_field
 
@@ -20,13 +15,11 @@ class SectionSlugManager(models.Manager):
             slug = slug[1:]
         section_slug, content_slug = slug.rsplit("/", 1)
         section_slug += "/"
-
-        primary = {self.slug_field: content_slug}
-        secondary = primary.copy()
-        primary["%s__full_slug" % self.primary_section_field] = section_slug
-        secondary["%s__full_slug" % self.section_field] = section_slug
-
-        qs = self.model.objects.filter(Q(**primary) | Q(**secondary))
+        kwargs = {
+                "%s__full_slug" % self.section_field: section_slug,
+                self.slug_field: content_slug,
+        }
+        qs = self.model.objects.filter(**kwargs)
         if hasattr(qs, "select_subclasses"):
             qs = qs.select_subclasses()
         try:


### PR DESCRIPTION
Increase the flexibility of the `find_related` backend by allowing it to search on multiple fields.

The `settings.ARMSTRONG_SECTION_ITEM_MODEL` may have more than one relation to Section. This would be true in the case of ManyToMany secondary sections with a ForeignKey primary_section. Using Q filter conditions means we can pick up any Model instances related to Section on any field.

Note: this doesn't care what relation fields are named and doesn't care how many there are.

This PR uses only one commit. I decided that SectionSlugManager should only utilize a single relation field.
