### PR TITLE
unique `full_slug`

### DIFF
--- a/armstrong/core/arm_sections/models.py
+++ b/armstrong/core/arm_sections/models.py
@@ -49,7 +49,7 @@ class Section(MPTTModel):
     title = models.CharField(max_length=255)
     summary = models.TextField(default="", blank=True)
     slug = models.SlugField()
-    full_slug = models.CharField(max_length=255, blank=True)
+    full_slug = models.CharField(max_length=255, blank=True, unique=True)
 
     parent = TreeForeignKey('self', null=True, blank=True)
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+from django.db import IntegrityError
 from django.core.exceptions import ImproperlyConfigured
 
 from armstrong.core.arm_sections.models import Section
@@ -155,6 +156,16 @@ class ModelTestCase(ArmSectionsTestCase):
         parent.save()
         child = Section.objects.get(slug="pro")  # have to reload
         self.assertEqual(child.full_slug, "sports/pro/")
+
+    def test_duplicate_root_level_full_slug_raises_error(self):
+        with self.assertRaises(IntegrityError):
+            Section.objects.create(title="duplicate", slug="sports")
+
+    def test_duplicate_nested_full_slug_raises_error(self):
+        parent = Section.objects.get(slug="sports")
+        with self.assertRaises(IntegrityError):
+            Section.objects.create(
+                title="duplicate", slug="pro", parent=parent)
 
 
 class ManagerTestCase(ArmSectionsTestCase):


### PR DESCRIPTION
Resolves armstrong/armstrong#84. This makes the `full_slug` unique.

There are plenty of cases and reasons for `slug` to duplicate across Sections (like "sports/local" and "weather/local" for an off the cuff example). `full_slug` has, I believe, always been intended as the unique identifier for Sections.
