### PR TITLE
use `get_queryset` for Django 1.6+

### DIFF
--- a/armstrong/core/arm_sections/models.py
+++ b/armstrong/core/arm_sections/models.py
@@ -20,7 +20,7 @@ SECTION_PUBLISHED_BACKEND = GenericBackend(
 
 
 class SectionManager(models.Manager):
-    def get_queryset(self):  # DROPWITHDJANGO15
+    def get_queryset(self):  # DROP_WITH_DJANGO15
         """Use the same ordering as TreeManager"""
 
         args = (self.model._mptt_meta.tree_id_attr,

--- a/tests/support/models.py
+++ b/tests/support/models.py
@@ -13,12 +13,12 @@ PUB_STATUS_CHOICES = (
 
 
 class PublishedManager(InheritanceManager):
-    def get_queryset(self):  # DROPWITHDJANGO15
+    def get_queryset(self):  # DROP_WITH_DJANGO15
         method = 'get_query_set' if django.VERSION < (1, 6) else 'get_queryset'
         return getattr(super(PublishedManager, self), method)()\
             .filter(pub_status="P")
 
-    if django.VERSION < (1, 6):  # DROPWITHDJANGO15
+    if django.VERSION < (1, 6):  # DROP_WITH_DJANGO15
         get_query_set = get_queryset
 
 


### PR DESCRIPTION
Django changed from `get_query_set()` to `get_queryset()` in Django 1.6 (which raises deprecation warnings).
