### PR TITLE
template tag test refactor

### DIFF
--- a/tests/support/fixtures/test_sections.json
+++ b/tests/support/fixtures/test_sections.json
@@ -80,7 +80,7 @@
   "fields": {
     "rght": 6,
     "parent": 5,
-    "title": "US sports",
+    "title": "US Sports",
     "level": 2,
     "summary": "All about US sports",
     "lft": 5,

--- a/tests/template_tags.py
+++ b/tests/template_tags.py
@@ -1,90 +1,98 @@
 import fudge
+from django.conf import settings
 from django.core import urlresolvers
-from django.template import Template, Context, TemplateSyntaxError
+from django.template import (
+    Template, Context, TemplateDoesNotExist, TemplateSyntaxError)
 
 from armstrong.core.arm_sections.models import Section
-from armstrong.core.arm_sections.templatetags import section_helpers
-
 from ._utils import ArmSectionsTestCase
-
-
-def generate_stub_resolve(val):
-    result = fudge.Fake()
-    result.provides('resolve').returns(val)
-    return result
 
 
 class SectionMenuTestCase(ArmSectionsTestCase):
     def setUp(self):
-        super(SectionMenuTestCase, self).setUp()
+        self.string = ""
+        self.context = Context()
+
+    def tearDown(self):
+        # Clear the cached template between test runs
+        if hasattr(self, '_rendered_template'):
+            del self._rendered_template
+
+    @classmethod
+    def setUpClass(cls):
+        """Set Template settings to known values"""
+        cls.old_td, settings.TEMPLATE_DEBUG = settings.TEMPLATE_DEBUG, False
+
+    @classmethod
+    def tearDownClass(cls):
+        settings.TEMPLATE_DEBUG = cls.old_td
+
+    @property
+    def rendered_template(self):
+        """Cache the rendered template result during a test run"""
+        if not hasattr(self, '_rendered_template'):  # pragma: no cover
+            template = "{% load section_helpers %}" + self.string
+            self._rendered_template = Template(template).render(self.context)
+        return self._rendered_template
 
     def test_render_without_parameters(self):
-        node = section_helpers.SectionMenuNode()
-        result = node.render(None)
-        for section in self.sections:
-            self.assertTrue(section.title in result)
-            self.assertFalse("<a href" in result)
+        self.string = '{% section_menu %}'
+        self.assertNotIn("<a href", self.rendered_template)
+        for section in Section.objects.all():
+            self.assertIn(section.title, self.rendered_template)
+
+    def test_tag_only_accepts_kwargs(self):
+        err = "accepts only keyword arguments"
+        self.string = '{% section_menu "will break" %}'
+        with self.assertRaisesRegexp(TemplateSyntaxError, err):
+            self.rendered_template
+
+    def test_render_with_custom_template(self):
+        self.string = '{% section_menu template="test_sections.html" %}'
+        self.assertNotIn("<a href", self.rendered_template)
+        self.assertEqual(u'This is the test template\n', self.rendered_template)
+
+    def test_missing_custom_template_raises_error(self):
+        self.string = '{% section_menu template="FOO/BAR/BAZ.html" %}'
+        with self.assertRaises(TemplateDoesNotExist):
+            self.rendered_template
 
     def test_render_with_section_view(self):
         reverse = fudge.Fake()
         link = "/link/to/section"
         reverse.is_callable().returns(link)
-        # section_view doesn't need to be wrapped, because the value is passed
-        # unchanged to the url tag which does the right thing regardless
-        node = section_helpers.SectionMenuNode(section_view="nonsense")
+        self.string = '{% section_menu section_view="nonsense" %}'
+
         with fudge.patched_context(urlresolvers, "reverse", reverse):
-            result = node.render(None)
-            for section in self.sections:
+            for section in Section.objects.all():
                 section_link = "<a href='%s'>%s</a>" % (link, section.title)
-                self.assertTrue(section_link in result)
+                self.assertIn(section_link, self.rendered_template)
 
-    def test_render_with_custom_template(self):
-        node = section_helpers.SectionMenuNode(
-            template=generate_stub_resolve('test_sections.html'))
-        result = node.render(None)
-        self.assertEqual(result, u'This is the test template\n')
+    def test_section_view_must_be_in_urlconf(self):
+        self.string = '{% section_menu section_view="nonsense" %}'
+        with self.assertRaises(urlresolvers.NoReverseMatch):
+            self.rendered_template
 
-    def test_render_with_node_subset(self):
-        sports = self.sections[1]
-        subset = Section.objects.filter(tree_id=sports.tree_id)
-        subset = generate_stub_resolve(subset)
-        node = section_helpers.SectionMenuNode(sections=subset)
-        result = node.render(None)
-        for section in self.sections:
-            if section.tree_id == sports.tree_id:
-                self.assertTrue(section.title in result)
+    def test_render_with_sections_subset(self):
+        subset = Section.objects.filter(full_slug__startswith="sports")
+        self.context['subset'] = subset
+        self.string = '{% section_menu sections=subset %}'
+
+        for section in Section.objects.all():
+            if section in subset:
+                self.assertIn(section.title, self.rendered_template)
             else:
-                self.assertFalse(section.title in result)
+                self.assertNotIn(section.title, self.rendered_template)
 
-    def test_section_menu_parser_empty(self):
-        template = Template(
-            '{% load section_helpers %}' +
-            '{% section_menu %}')
-        section_node = template.nodelist[1]
-        Section.objects.all().order_by('tree_id')
-        self.assertIsInstance(section_node, section_helpers.SectionMenuNode)
-        self.assertIsNone(section_node.sections)
-        self.assertIsNone(section_node.section_view)
-        self.assertIsNone(section_node.template)
+    def test_subsections_nest_properly(self):
+        subset = Section.objects.filter(full_slug__startswith="sports")
+        self.context['subset'] = subset
+        self.string = '{% section_menu sections=subset %}'
 
-    def test_section_menu_parser_template(self):
-        template = Template(
-            '{% load section_helpers %}' +
-            '{% section_menu template="FOO/BAR/BAZ.html" %}')
-        section_node = template.nodelist[1]
-        self.assertEqual(
-            section_node.template.resolve({}),
-            'FOO/BAR/BAZ.html')
+        occurrences = self.rendered_template.count('<ul class="children">')
+        self.assertEqual(occurrences, 2)
 
-    def test_render_from_template_with_custom_template(self):
-        template = Template(
-            '{% load section_helpers %}' +
-            '{% section_menu template="test_sections.html" %}')
-        result = template.render(Context({}))
-        self.assertEqual(result, u'This is the test template\n')
-
-    def test_section_menu_parser_invalid(self):
-        with self.assertRaises(TemplateSyntaxError):
-            Template(
-                '{% load section_helpers %}' +
-                '{% section_menu "test_sections.html" %}')
+    def test_empty_sections_yields_empty_list(self):
+        self.context['subset'] = []
+        self.string = '{% section_menu sections=subset %}'
+        self.assertNotIn("<li>", self.rendered_template)


### PR DESCRIPTION
Test the tag in template use, not the Node. Removing the implementation details is the same change we made to ArmLayout in armstrong/armstrong.core.arm_layout#12. Add a couple new scenarios as well.

I did this so we could refactor the template tag into a `simple_tag`. Piece of cake. Except for Django 1.3. Currently, and I'd like to maintain this, the tag only accepts `kwargs`. I don't want to change the behavior and I like the explicit meaning when using kwargs. Call me nostalgic, but the code already exists and we've maintained compatibility so far. I'd like to keep Django 1.3 support.

In Django 1.4 [simple_tag](https://docs.djangoproject.com/en/1.4/howto/custom-template-tags/#simple-tags) can take arbitrary kwargs.

> New in Django 1.4: simple_tag functions may accept any number of positional or keyword arguments.
